### PR TITLE
Add validation for Ethyrea categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,15 @@ cp .env.example .env.local
 pnpm dev
 ```
 
+### Validate content categories
+
+Run the test suite to verify that every category listed in `categories.json` has
+corresponding content files and UI entries:
+
+```bash
+npm test
+# or
+pnpm test
+```
+
+

--- a/categories.json
+++ b/categories.json
@@ -1,0 +1,8 @@
+{
+  "characters": ["mainProtagonists.json", "antagonists.json"],
+  "worldbuilding": ["geography/mountains.json", "flora/magicalPlants.json"],
+  "magic": ["leyLines.json", "spells.json"],
+  "artifacts": ["artifacts.json"],
+  "lore": ["myths.json"]
+}
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "vitest run"
+    "test": "node tests/validate-categories.js && vitest run"
   },
   "devDependencies": {
     "typescript": "^5.6.3",

--- a/tests/validate-categories.js
+++ b/tests/validate-categories.js
@@ -1,0 +1,41 @@
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const root = process.cwd();
+const categoriesPath = join(root, 'categories.json');
+const uiPath = join(root, 'ethyrea', 'index.html');
+
+const categories = JSON.parse(readFileSync(categoriesPath, 'utf8'));
+const uiContent = readFileSync(uiPath, 'utf8');
+
+let hasError = false;
+
+for (const [category, files] of Object.entries(categories)) {
+  const dir = join(root, 'ethyrea', category);
+  if (!existsSync(dir)) {
+    console.error(`Missing directory for category: ${category}`);
+    hasError = true;
+    continue;
+  }
+
+  for (const file of files) {
+    const filePath = join(dir, file);
+    if (!existsSync(filePath)) {
+      console.error(`Missing file for ${category}: ${file}`);
+      hasError = true;
+    }
+  }
+
+  const uiRegex = new RegExp(`data-category=["']${category}["']`);
+  if (!uiRegex.test(uiContent)) {
+    console.error(`Missing UI entry for category: ${category}`);
+    hasError = true;
+  }
+}
+
+if (hasError) {
+  process.exit(1);
+} else {
+  console.log('All categories validated successfully.');
+}
+


### PR DESCRIPTION
## Summary
- add `categories.json` describing expected content files
- add node script `tests/validate-categories.js` to ensure each category has files and UI entries
- run validation in `npm test` and document usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898ed2247d083219cdc32890cabf1f4