### PR TITLE
Add restructuring plan and artwork header

### DIFF
--- a/artwork.html
+++ b/artwork.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>McTigueINK Artwork</title>
+  <link rel="stylesheet" href="css/artwork.css">
+</head>
+<body>
+  <header>
+    <h1>McTigueINK Artwork</h1>
+  </header>
+  <main>
+    <section>
+      <h2>Featured Landscape</h2>
+      <img src="images/landscape-header.jpg" alt="Landscape painting header placeholder">
+      <p>Replace this placeholder image with one of your own landscape paintings to showcase your artwork.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/css/artwork.css
+++ b/css/artwork.css
@@ -1,0 +1,29 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  color: #333;
+  background-color: #f5f5f5;
+}
+
+header {
+  background-image: url('../images/landscape-header.jpg');
+  background-size: cover;
+  background-position: center;
+  height: 300px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  text-shadow: 0 0 10px rgba(0,0,0,0.7);
+}
+
+main {
+  padding: 1rem;
+}
+
+section img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+}

--- a/docs/restructure-plan.md
+++ b/docs/restructure-plan.md
@@ -1,0 +1,46 @@
+# McTigueINK Website Restructure Plan
+
+This document outlines how to rebuild the repository into a sales-focused site for McTigueINK art, courses, and merchandise.
+
+## Goals
+- Replace existing prototype content with a streamlined sales website.
+- Highlight artwork, digital courses, and physical products.
+- Preserve the existing domain configuration (`CNAME`) and use environment variables for any API keys.
+
+## Proposed Directory Structure
+```
+/
+├── index.html             # landing page with product highlights
+├── artwork.html           # dedicated gallery page (example added)
+├── products/              # individual product pages
+├── courses/               # course descriptions and enrollment links
+├── images/                # artwork and site graphics
+├── css/                   # stylesheets
+├── js/                    # scripts for interactivity/cart
+├── server.js (optional)   # server or API hooks if needed
+└── docs/                  # documentation and planning
+```
+
+## Implementation Steps
+1. **Remove deprecated files**
+   - Archive or delete current prototype code that will not be reused.
+2. **Create core pages**
+   - `index.html` for the main sales landing page.
+   - Individual pages for artwork, courses, and products.
+3. **Design and branding**
+   - Apply McTigueINK colors, fonts, and logo consistently.
+   - Use high-quality images for artwork and promotional banners.
+4. **E-commerce integration**
+   - Integrate a service such as Stripe, Snipcart, or Shopify Buy Buttons for checkout.
+   - Store API keys in environment variables or deployment platform secrets (never commit keys).
+5. **Deployment**
+   - Continue using the existing domain (`mctigueink.com`) via the `CNAME` file.
+   - Deploy to GitHub Pages, Netlify, or a similar host with CI/CD.
+6. **Testing and maintenance**
+   - Add tests for any dynamic functionality.
+   - Document future updates and keep dependencies current.
+
+## Next Steps
+- Replace placeholder images with original artwork.
+- Flesh out product data and course listings.
+- Configure payment provider and shipping/tax settings as needed.

--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,3 @@
+# Images Directory
+
+Place site images here. For the artwork header, add your landscape painting as `landscape-header.jpg` and update references if needed.


### PR DESCRIPTION
## Summary
- outline plan to rebuild repo into a sales-focused McTigueINK site
- add sample artwork page with landscape header styling
- document image placement for future artwork

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad2986d90883219d361c23693c74e7