### PR TITLE
Add books page with Amazon links

### DIFF
--- a/books.html
+++ b/books.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Books - McTigueINK</title>
+  <link rel="stylesheet" href="css/site.css">
+</head>
+<body>
+  <header class="site-header">
+    <img src="images/mctigueink-logo.png" alt="McTigueINK logo" class="site-logo">
+    <nav>
+      <a href="index.html#art">Art</a>
+      <a href="https://payhip.com/McTigueINK" target="_blank" rel="noopener">Courses</a>
+      <a href="index.html#merch">Merch</a>
+      <a href="books.html">Books</a>
+      <a href="index.html#consumables">Consumables</a>
+      <a href="index.html#programs">Programs</a>
+    </nav>
+    <button class="checkout-btn">Cart (<span class="snipcart-items-count">0</span>)</button>
+  </header>
+  <main>
+    <section id="books" class="product-section">
+      <h2>Books</h2>
+      <div class="product-grid">
+        <div class="product-card">
+          <img src="https://covers.openlibrary.org/b/isbn/0743273567-L.jpg" alt="Cover of The Great Gatsby">
+          <h3>The Great Gatsby</h3>
+          <p>A classic tale of wealth and obsession set in the Jazz Age.</p>
+          <a class="amazon-btn" href="https://www.amazon.com/dp/0743273567?tag=yourtag-20" target="_blank" rel="noopener">Buy on Amazon</a>
+        </div>
+        <div class="product-card">
+          <img src="https://covers.openlibrary.org/b/isbn/0451524934-L.jpg" alt="Cover of 1984">
+          <h3>1984</h3>
+          <p>George Orwell's dystopian novel on totalitarian surveillance and control.</p>
+          <a class="amazon-btn" href="https://www.amazon.com/dp/0451524934?tag=yourtag-20" target="_blank" rel="noopener">Buy on Amazon</a>
+        </div>
+        <div class="product-card">
+          <img src="https://covers.openlibrary.org/b/isbn/0316769487-L.jpg" alt="Cover of The Catcher in the Rye">
+          <h3>The Catcher in the Rye</h3>
+          <p>Holden Caulfield's coming-of-age journey through New York City.</p>
+          <a class="amazon-btn" href="https://www.amazon.com/dp/0316769487?tag=yourtag-20" target="_blank" rel="noopener">Buy on Amazon</a>
+        </div>
+      </div>
+      <div class="amazon-storefront">
+        <iframe scrolling="no" frameborder="0" src="https://ws-na.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=US&source=ac&ref=tf_til&ad_type=responsive_search_widget&tracking_id=yourtag-20&marketplace=amazon&region=US&placement=&asins=&linkId=123456&search=books&show_border=true&link_opens_in_new_window=true"></iframe>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2024 McTigueINK</p>
+  </footer>
+  <script src="js/apliiq.js"></script>
+  <script src="js/cart.js"></script>
+  <script src="js/checkout.js"></script>
+</body>
+</html>

--- a/css/site.css
+++ b/css/site.css
@@ -56,3 +56,26 @@ footer {
 .site-logo {
     height: 60px;
 }
+.amazon-btn {
+  display: inline-block;
+  background: #ff9900;
+  color: #000;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  text-decoration: none;
+}
+
+.amazon-btn:hover {
+  background: #e68a00;
+}
+
+.amazon-storefront {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.amazon-storefront iframe {
+  width: 100%;
+  height: 400px;
+  border: none;
+}

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
             <a href="#art">Art</a>
             <a href="https://payhip.com/McTigueINK" target="_blank" rel="noopener">Courses</a>
             <a href="#merch">Merch</a>
-            <a href="#books">Books</a>
+            <a href="books.html">Books</a>
             <a href="#consumables">Consumables</a>
             <a href="#programs">Programs</a>
         </nav>
@@ -70,11 +70,7 @@
 
         <section id="books" class="product-section">
             <h2>Books</h2>
-            <div class="product-grid">
-                <div class="product-card">
-                    <p>Coming soon</p>
-                </div>
-            </div>
+            <p><a href="books.html">Browse our books on the dedicated page.</a></p>
         </section>
 
         <section id="consumables" class="product-section">


### PR DESCRIPTION
## Summary
- Add books.html page with sample titles, cover images, Amazon affiliate buttons, and storefront widget
- Style Amazon buttons and storefront iframe in site.css
- Link index navigation to new Books page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b637dcc62083219f833296eb77f9fd