### PR TITLE
Add Snipcart API key loader and artwork product page

### DIFF
--- a/artwork.html
+++ b/artwork.html
@@ -3,19 +3,40 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>McTigueINK Artwork</title>
-  <link rel="stylesheet" href="css/artwork.css">
+  <title>Landscape Print - McTigueINK Store</title>
+  <link rel="stylesheet" href="css/site.css">
 </head>
 <body>
-  <header>
-    <h1>McTigueINK Artwork</h1>
+  <header class="site-header">
+    <img src="images/mctigueink-logo.png" alt="McTigueINK logo" class="site-logo">
+    <nav>
+      <a href="index.html">Home</a>
+    </nav>
+    <button class="checkout-btn">Cart (<span class="snipcart-items-count">0</span>)</button>
   </header>
-  <main>
-    <section>
+  <main class="product-section">
+    <div class="product-card">
       <h2>Featured Landscape</h2>
-      <img src="../images/landscape-header.jpg" alt="Landscape painting of a serene valley at sunset">
+      <img src="images/landscape-header.jpg" alt="Landscape painting of a serene valley at sunset">
       <p>A tranquil landscape painting of rolling hills glowing beneath a vibrant sunset.</p>
-    </section>
+      <button class="snipcart-add-item"
+              data-item-id="landscape-print"
+              data-item-name="Landscape Print"
+              data-item-price="150.00"
+              data-item-url="/artwork.html"
+              data-item-description="Tranquil landscape painting print">
+        Add to cart
+      </button>
+    </div>
   </main>
+  <footer>
+    <p>&copy; 2024 McTigueINK</p>
+  </footer>
+  <script src="js/apliiq.js"></script>
+  <script>
+    window.SNIPCART_PUBLIC_API_KEY = window.SNIPCART_PUBLIC_API_KEY || '';
+  </script>
+  <script src="js/cart.js"></script>
+  <script src="js/checkout.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
                         data-item-id="brand-tee"
                         data-item-name="Brand Tee"
                         data-item-price="20.00"
-                        data-item-url="/"
+                        data-item-url="/index.html"
                         data-item-description="Soft cotton tee with McTigueINK logo">
                         Add to cart
                     </button>
@@ -100,6 +100,9 @@
         <p>&copy; 2024 McTigueINK</p>
     </footer>
     <script src="js/apliiq.js"></script>
+    <script>
+        window.SNIPCART_PUBLIC_API_KEY = window.SNIPCART_PUBLIC_API_KEY || '';
+    </script>
     <script src="js/cart.js"></script>
     <script src="js/checkout.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Ensure home page Add to cart button references its URL and expose Snipcart API key before loading cart scripts
- Add dedicated artwork product page with Add to cart button and cart integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b637cfac188321b5d9e18481114996