### PR TITLE
Add Creative Hub config and verify Apliiq URLs

### DIFF
--- a/artwork.html
+++ b/artwork.html
@@ -17,5 +17,8 @@
       <p>A tranquil landscape painting of rolling hills glowing beneath a vibrant sunset.</p>
     </section>
   </main>
+  <!-- Endpoint URLs must be defined on window.APLIIQ_* and window.CREATIVEHUB_* before these scripts load -->
+  <script src="js/apliiq.js"></script>
+  <script src="js/creativehub.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -99,7 +99,9 @@
     <footer>
         <p>&copy; 2024 McTigueINK</p>
     </footer>
+    <!-- Endpoint URLs must be defined on window.APLIIQ_* and window.CREATIVEHUB_* before these scripts load -->
     <script src="js/apliiq.js"></script>
+    <script src="js/creativehub.js"></script>
     <script src="js/cart.js"></script>
     <script src="js/checkout.js"></script>
 </body>

--- a/js/apliiq.js
+++ b/js/apliiq.js
@@ -1,9 +1,11 @@
 (() => {
   const fulfillmentUrl = window.APLIIQ_FULFILLMENT_URL;
   const warehouseUrl = window.APLIIQ_WAREHOUSE_URL;
-  if (!fulfillmentUrl || !warehouseUrl) {
-    console.warn('Apliiq URLs missing. Set APLIIQ_FULFILLMENT_URL and APLIIQ_WAREHOUSE_URL.');
+
+  if (typeof fulfillmentUrl !== 'string' || typeof warehouseUrl !== 'string') {
+    console.warn('Apliiq URLs missing. Set APLIIQ_FULFILLMENT_URL and APLIIQ_WAREHOUSE_URL before loading apliiq.js.');
     return;
   }
+
   window.ApliiqConfig = { fulfillmentUrl, warehouseUrl };
 })();

--- a/js/creativehub.js
+++ b/js/creativehub.js
@@ -1,0 +1,11 @@
+(() => {
+  const keys = Object.keys(window).filter(k => /^CREATIVEHUB_.+_URL$/.test(k));
+  if (keys.length === 0) {
+    console.warn('Creative Hub URLs missing. Define CREATIVEHUB_*_URL variables before loading creativehub.js.');
+    return;
+  }
+  window.CreativeHubConfig = keys.reduce((cfg, key) => {
+    cfg[key] = window[key];
+    return cfg;
+  }, {});
+})();


### PR DESCRIPTION
## Summary
- verify Apliiq URLs exist before configuration
- expose Creative Hub configuration from runtime `window.CREATIVEHUB_*` variables
- load Apliiq and Creative Hub scripts on site pages with runtime credential hooks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b637bc3b408321a4082399071454df