### PR TITLE
Add standalone category pages and navigation

### DIFF
--- a/artwork.html
+++ b/artwork.html
@@ -1,21 +1,42 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>McTigueINK Artwork</title>
-  <link rel="stylesheet" href="css/artwork.css">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Artwork - McTigueINK Store</title>
+    <link rel="stylesheet" href="css/site.css">
 </head>
 <body>
-  <header>
-    <h1>McTigueINK Artwork</h1>
-  </header>
-  <main>
-    <section>
-      <h2>Featured Landscape</h2>
-      <img src="../images/landscape-header.jpg" alt="Landscape painting of a serene valley at sunset">
-      <p>A tranquil landscape painting of rolling hills glowing beneath a vibrant sunset.</p>
-    </section>
-  </main>
+    <header class="site-header">
+        <img src="images/mctigueink-logo.png" alt="McTigueINK logo" class="site-logo">
+        <nav>
+            <a href="index.html">Home</a>
+            <a href="artwork.html">Artwork</a>
+            <a href="digital.html">Digital</a>
+            <a href="merch.html">Merch</a>
+            <a href="books.html">Books</a>
+        </nav>
+        <button class="checkout-btn">Cart (<span class="snipcart-items-count">0</span>)</button>
+    </header>
+
+    <main>
+        <section id="artwork" class="product-section">
+            <h2>Artwork</h2>
+            <div class="product-grid">
+                <div class="product-card">
+                    <img src="images/artwork.jpg" alt="Colorful sample artwork from McTigueINK">
+                    <h3>Landscape Print</h3>
+                    <p>Coming soon</p>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2024 McTigueINK</p>
+    </footer>
+    <script src="js/apliiq.js"></script>
+    <script src="js/cart.js"></script>
+    <script src="js/checkout.js"></script>
 </body>
 </html>

--- a/books.html
+++ b/books.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>McTigueINK Store</title>
+    <title>Books - McTigueINK Store</title>
     <link rel="stylesheet" href="css/site.css">
 </head>
 <body>
@@ -20,26 +20,11 @@
     </header>
 
     <main>
-        <section id="hero">
-            <h2>Bring Imagination to Life</h2>
-            <p>Discover original artwork, creative courses, and more.</p>
-        </section>
-
-        <section id="featured" class="product-section">
-            <h2>Featured Products</h2>
+        <section id="books" class="product-section">
+            <h2>Books</h2>
             <div class="product-grid">
                 <div class="product-card">
-                    <img src="images/merch.jpg" alt="Black T-shirt featuring the McTigueINK logo">
-                    <h3>Brand Tee</h3>
-                    <p>Soft cotton tee with McTigueINK logo.</p>
-                    <button class="snipcart-add-item"
-                        data-item-id="brand-tee"
-                        data-item-name="Brand Tee"
-                        data-item-price="20.00"
-                        data-item-url="/"
-                        data-item-description="Soft cotton tee with McTigueINK logo">
-                        Add to cart
-                    </button>
+                    <p>Coming soon</p>
                 </div>
             </div>
         </section>

--- a/digital.html
+++ b/digital.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>McTigueINK Store</title>
+    <title>Digital Products - McTigueINK Store</title>
     <link rel="stylesheet" href="css/site.css">
 </head>
 <body>
@@ -20,26 +20,14 @@
     </header>
 
     <main>
-        <section id="hero">
-            <h2>Bring Imagination to Life</h2>
-            <p>Discover original artwork, creative courses, and more.</p>
-        </section>
-
-        <section id="featured" class="product-section">
-            <h2>Featured Products</h2>
+        <section id="digital" class="product-section">
+            <h2>Digital Products</h2>
+            <p><a href="https://payhip.com/McTigueINK" target="_blank" rel="noopener">Browse our courses on Payhip</a>.</p>
             <div class="product-grid">
                 <div class="product-card">
-                    <img src="images/merch.jpg" alt="Black T-shirt featuring the McTigueINK logo">
-                    <h3>Brand Tee</h3>
-                    <p>Soft cotton tee with McTigueINK logo.</p>
-                    <button class="snipcart-add-item"
-                        data-item-id="brand-tee"
-                        data-item-name="Brand Tee"
-                        data-item-price="20.00"
-                        data-item-url="/"
-                        data-item-description="Soft cotton tee with McTigueINK logo">
-                        Add to cart
-                    </button>
+                    <img src="images/course.jpg" alt="Desk setup representing an upcoming creative course">
+                    <h3>Writing Workshop</h3>
+                    <p>Coming soon</p>
                 </div>
             </div>
         </section>

--- a/merch.html
+++ b/merch.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>McTigueINK Store</title>
+    <title>Merchandise - McTigueINK Store</title>
     <link rel="stylesheet" href="css/site.css">
 </head>
 <body>
@@ -20,13 +20,8 @@
     </header>
 
     <main>
-        <section id="hero">
-            <h2>Bring Imagination to Life</h2>
-            <p>Discover original artwork, creative courses, and more.</p>
-        </section>
-
-        <section id="featured" class="product-section">
-            <h2>Featured Products</h2>
+        <section id="merch" class="product-section">
+            <h2>Merchandise</h2>
             <div class="product-grid">
                 <div class="product-card">
                     <img src="images/merch.jpg" alt="Black T-shirt featuring the McTigueINK logo">


### PR DESCRIPTION
## Summary
- Create dedicated pages for Artwork, Digital products, Merch, and Books using the index template
- Simplify homepage with featured products section and cross-site navigation links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b637b8d1608321af456df2a0a19936