### PR TITLE
docs: add IP readiness toolkit

### DIFF
--- a/docs/world-expansion/toolkit.md
+++ b/docs/world-expansion/toolkit.md
@@ -1,3 +1,45 @@
 # World Expansion OS — IP Readiness Toolkit (v1)
 
-<!-- TODO: Replace this placeholder with the full "World Expansion OS — IP Readiness Toolkit (v1)" text. -->
+The **World Expansion OS — IP Readiness Toolkit (v1)** provides a checklist and
+supporting references to prepare a story world for licensing and
+cross‑platform growth.
+
+## Asset inventory
+
+- Catalogue characters, locations, items, and key story beats.
+- Link each asset to its canonical source files and metadata.
+
+## Rights and ownership
+
+- Identify IP owners and contributors for every asset.
+- Note any third‑party rights or encumbrances.
+- Provide contact details for licensing inquiries.
+
+## Usage guidelines
+
+- Maintain consistent naming conventions and style guides.
+- Define approved logo usage, color palettes, and tone of voice.
+- Include references for visual and textual continuity.
+
+## Documentation
+
+- Track revisions with version numbers and change logs.
+- Store release forms and agreements alongside related assets.
+- Reference templates for contracts and contributor agreements.
+
+## Distribution & access
+
+- Describe how partners can access assets (repository URLs, asset libraries,
+  etc.).
+- Outline review and approval workflows for new derivatives.
+
+## Support
+
+- List contacts for legal, creative, and technical questions.
+- Link to community forums or knowledge bases when available.
+
+---
+
+The canonical version of this toolkit is maintained at:
+https://mctigueink.github.io/world-expansion/ip-readiness-toolkit-v1
+


### PR DESCRIPTION
## Summary
- add World Expansion OS IP readiness toolkit with licensing and documentation guidelines

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b83291af948321b1f9a66ab1e444f7